### PR TITLE
bumped grpc and python version to build on macos

### DIFF
--- a/plugins/python-auth-plugin/Dockerfile
+++ b/plugins/python-auth-plugin/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11
 LABEL maintainer="ForAllSecure Team <mayhem4api@forallsecure.com>"
 ARG port=9001
 ENV MAPI_PLUGIN_PORT=$port

--- a/plugins/python-auth-plugin/requirements.txt
+++ b/plugins/python-auth-plugin/requirements.txt
@@ -1,2 +1,4 @@
-grpcio==1.38.1
-grpcio-tools==1.38.1
+grpcio==1.51.1
+grpcio-tools==1.51.1
+protobuf==4.21.12
+six==1.16.0


### PR DESCRIPTION
Build was failing on macos ventura and python 3.11 docker image.

This PR updates grpc to version 1.51.1 and the docker image to use python 3.11. Confirmed it builds on macos ventura and in docker.
